### PR TITLE
[build] add support for EFR32 devices on Thread 1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-build
-build-1.1
-build-1.2
-build-1.3
+build*
 output
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 build
+build-1.1
+build-1.2
+output
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 build-1.1
 build-1.2
+build-1.3
 output
 .idea

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,4 +19,4 @@
 	url = https://github.com/openthread/openthread.git
 [submodule "ot-efr32"]
 	path = ot-efr32
-	url = git@github.com:openthread/ot-efr32.git
+	url = https://github.com/openthread/ot-efr32

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,6 @@
 [submodule "openthread-1.1"]
 	path = openthread-1.1
 	url = https://github.com/openthread/openthread.git
+[submodule "ot-efr32"]
+	path = ot-efr32
+	url = git@github.com:openthread/ot-efr32.git

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ At the root of the repository:
 $ REFERENCE_RELEASE_TYPE=(certification|1.3)  [SD_CARD=/dev/...] [IN_CHINA=(0|1)] ./script/make-reference-release.bash
 ```
 
-This will produce a reference release folder in `./build/`. The folder will be 
+This will produce a reference release folder in `./build/`. The folder will be
 named after the release type, date and the OpenThread commit id.
 
-`SD_CARD` is expected to be the device file path of an SD card inserted to 
-the host. If this variable is specified, the script will flash the Raspberry Pi 
+`SD_CARD` is expected to be the device file path of an SD card inserted to
+the host. If this variable is specified, the script will flash the Raspberry Pi
 image containing OpenThread border router service to the SD card.
 
 If `IN_CHINA` is set to 1, the script will prefer to use apt sources based in
@@ -34,7 +34,7 @@ China so that you can save time while installing software dependencies.
 For example, if you are in China and want to flash the built image to an SD card:
 
 ```
-$ REFERENCE_RELEASE_TYPE=certification IN_CHINA=1 SD_CARD=/dev/sda ./script/make-reference-release.bash 
+$ REFERENCE_RELEASE_TYPE=certification IN_CHINA=1 SD_CARD=/dev/sda ./script/make-reference-release.bash
 ```
 
 When `REFERENCE_RELEASE_TYPE` is `certification`, reference release contains following components:
@@ -49,8 +49,6 @@ When `REFERENCE_RELEASE_TYPE` is `1.3`, reference release contains following com
 - Firmware
 - Change log
 - Quick start guide
-
-Note: Currently, only nRF52840 dongles are supported for CLI/RCP firmwares.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ When `REFERENCE_RELEASE_TYPE` is `1.3`, reference release contains following com
 - Change log
 - Quick start guide
 
-- Note: Currently, only nRF52840 dongles and EFR32MG12 BRD4166A boards are supported for CLI/RCP firmwares.
+Note: Currently, only nRF52840 dongles and EFR32MG12 BRD4166A boards are supported for CLI/RCP firmwares.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ When `REFERENCE_RELEASE_TYPE` is `1.3`, reference release contains following com
 - Change log
 - Quick start guide
 
+- Note: Currently, only nRF52840 dongles and EFR32MG12 BRD4166A boards are supported for CLI/RCP firmwares.
+
 # Contributing
 
 We would love for you to contribute to OpenThread and help make it even better than it is today! See our [Contributing Guidelines](https://github.com/openthread/openthread/blob/main/CONTRIBUTING.md) for more information.

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -128,6 +128,7 @@ package()
         return
     fi
     arm-none-eabi-objcopy -O ihex "$binary_path" "${hex_file}"
+    arm-none-eabi-objcopy -O ihex "$binary_path" "${hex_file}"
 
     # Zip
     local zip_file="${basename}-${thread_version}-${timestamp}-${commit_id}.zip"
@@ -277,7 +278,9 @@ main()
     shift
 
     # Print OUTPUT_ROOT. Error if OUTPUT_ROOT is not defined
-    echo "OUTPUT_ROOT=${OUTPUT_ROOT?}"
+    OUTPUT_ROOT=$(realpath ${OUTPUT_ROOT?})
+    echo "OUTPUT_ROOT=${OUTPUT_ROOT}"
+    mkdir -p ${OUTPUT_ROOT}
 
     # ==========================================================================
     # Prebuild

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -284,11 +284,17 @@ main()
     # ==========================================================================
     case "${platform}" in
         nrf*)
-            # Setup nrfutil-linux
-            NRFUTIL=/tmp/nrfutil-linux
+            # Setup nrfutil
+            if [[ $OSTYPE == "linux"* ]]; then
+                ostype=linux
+            elif [[ $OSTYPE == "darwin"* ]]; then
+                ostype=mac
+            fi
+            NRFUTIL=/tmp/nrfutil-${ostype}
+
             if [ ! -f $NRFUTIL ]; then
-            wget -O $NRFUTIL https://github.com/NordicSemiconductor/pc-nrfutil/releases/download/v6.1/nrfutil-linux
-            chmod +x $NRFUTIL
+                wget -O $NRFUTIL https://github.com/NordicSemiconductor/pc-nrfutil/releases/download/v6.1/nrfutil-${ostype}
+                chmod +x $NRFUTIL
             fi
 
             # Generate private key

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -183,8 +183,8 @@ build()
             cd openthread-1.1
 
             # Prep
-            # git clean -xfd
-            # ./bootstrap
+            git clean -xfd
+            ./bootstrap
 
             # Build
             options=("${build_1_1_env_common[@]}")
@@ -208,7 +208,7 @@ build()
             done
 
             # Clean up
-            # git clean -xfd
+            git clean -xfd
             ;;
     esac
 
@@ -262,7 +262,7 @@ main()
                 build ot-nrf528xx 1.1 "$@"
                 ;;
             efr32*)
-                # build ot-efr32 1.2 "$@"
+                build ot-efr32 1.2 "$@"
                 build ot-efr32 1.1 "$@"
                 ;;
         esac

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -182,7 +182,7 @@ build()
                     options+=("${build_1_3_options_nrf[@]}")
                     ;;
                 efr32*)
-                    BOARD=${BOARD?Please specify EFR32 board}
+                    BOARD=${BOARD?Please specify a EFR32 board}
                     options+=("-DBOARD=${BOARD}" ${build_1_3_options_efr32[@]})
                     ;;
             esac

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -146,7 +146,8 @@ package()
 }
 
 # Envionment variables:
-# - build_type:     Type of build (optional)
+# - build_type:             Type of build (optional)
+# - build_script_flags:     Any flags specific to the platform repo's build script (optional)
 # Args:
 # - $1 - thread_version: Thread version number, e.g. 1.2
 # - $2 - platform_repo:  Path to platform's repo, e.g. ot-efr32, ot-nrf528xx
@@ -178,7 +179,7 @@ build()
                     options+=("-DBOARD=brd4166a" ${build_1_3_options_efr32[@]})
                     ;;
             esac
-            OT_CMAKE_BUILD_DIR=${build_dir} ./script/build ${platform} ${build_type:-""} "${options[@]}" "$@"
+            OT_CMAKE_BUILD_DIR=${build_dir} ./script/build ${build_script_flags:-""} ${platform} ${build_type:-""} "${options[@]}" "$@"
 
             # Package and distribute
             local dist_apps=(
@@ -326,7 +327,7 @@ main()
                 ;;
             efr32*)
                 platform_repo=ot-efr32
-                thread_version=1.3 build "$@"
+                build_script_flags="--skip-silabs-apps" thread_version=1.3 build "$@"
                 ;;
         esac
     else

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -161,9 +161,6 @@ build()
                 nrf*)
                     options+=("${build_1_2_options_nrf[@]}")
                     ;;
-                efr32*)
-                    options+=("-DBOARD=${BOARD}" ${build_1_2_options_efr32[@]})
-                    ;;
             esac
             OT_CMAKE_BUILD_DIR=${build_dir} ./script/build ${platform} ${build_type} "${options[@]}" "$@"
 
@@ -187,8 +184,7 @@ build()
             cd openthread-1.1
 
             # Prep
-            # TODO: Need to find some way to pull in GSDK 2.7 before starting efr32 builds in openthread 1.1
-            # git clean -xfd
+            git clean -xfd
             ./bootstrap
 
             # Build
@@ -196,9 +192,6 @@ build()
             case "${platform}" in
                 nrf*)
                     options+=("${build_1_1_env_nrf[@]}")
-                    ;;
-                efr32*)
-                    options+=(${build_1_1_env_efr32[@]} BOARD=$(echo $BOARD | tr [a-z] [A-Z]))
                     ;;
             esac
             make -f examples/Makefile-${platform} "${options[@]}" "$@"
@@ -213,8 +206,7 @@ build()
             done
 
             # Clean up
-            # TODO: Need to find some way to pull in GSDK 2.7 before starting efr32 builds in openthread 1.1
-            # git clean -xfd
+            git clean -xfd
             ;;
     esac
 
@@ -267,10 +259,6 @@ main()
                 build ot-nrf528xx 1.2 "$@"
                 build ot-nrf528xx 1.1 "$@"
                 ;;
-            efr32*)
-                build ot-efr32 1.2 "$@"
-                build ot-efr32 1.1 "$@"
-                ;;
         esac
     elif [ "${REFERENCE_RELEASE_TYPE}" = "1.3" ]; then
         case "${platform}" in
@@ -279,7 +267,7 @@ main()
                 package ot-rcp 1.2
                 ;;
             efr32*)
-                build ot-efr32 "$@"
+                build ot-efr32 1.3 "$@"
                 ;;
         esac
     fi

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -85,10 +85,6 @@ readonly build_1_2_options_common=(
     '-DOT_UDP_FORWARD=OFF'
 )
 
-readonly build_1_2_options_efr32=(
-    '-DOT_CSL_RECEIVER=OFF'
-)
-
 readonly build_1_2_options_nrf=(
     '-DOT_BOOTLOADER=USB'
     '-DOT_CSL_RECEIVER=ON'
@@ -103,10 +99,6 @@ readonly build_1_1_env_common=(
     'JOINER=1'
     'MAC_FILTER=1'
     'BOOTLOADER=1'
-)
-
-readonly build_1_1_env_efr32=(
-    ""
 )
 
 readonly build_1_1_env_nrf=(

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -42,7 +42,7 @@ repo_dir="$(dirname "$script_dir")"
 platform=""
 build_dir=""
 
-readonly OT_PLATFORMS=(nrf52840 efr32mg1 efr32mg12 efr32mg13 efr32mg21)
+readonly OT_PLATFORMS=(nrf52840 efr32mg12)
 
 readonly build_1_3_options_common=(
     ""
@@ -181,9 +181,8 @@ build()
                 nrf*)
                     options+=("${build_1_3_options_nrf[@]}")
                     ;;
-                efr32*)
-                    BOARD=${BOARD?Please specify a EFR32 board}
-                    options+=("-DBOARD=${BOARD}" ${build_1_3_options_efr32[@]})
+                efr32mg12)
+                    options+=("-DBOARD=brd4166a" ${build_1_3_options_efr32[@]})
                     ;;
             esac
             OT_CMAKE_BUILD_DIR=${build_dir} ./script/build ${platform} ${build_type:-""} "${options[@]}" "$@"

--- a/script/make-firmware.bash
+++ b/script/make-firmware.bash
@@ -113,6 +113,10 @@ package()
 
     # Generate .hex file
     local hex_file="${basename}"-"${thread_version}".hex
+    if [ ! -f "$binary_path" ]; then
+        echo "WARN: $binary_path does not exist. Skipping packaging"
+        return
+    fi
     arm-none-eabi-objcopy -O ihex "$binary_path" "${hex_file}"
 
     # Zip
@@ -158,7 +162,7 @@ build()
                     options+=("${build_1_2_options_nrf[@]}")
                     ;;
                 efr32*)
-                    options+=("${build_1_2_options_efr32[@]}")
+                    options+=("-DBOARD=${BOARD}" ${build_1_2_options_efr32[@]})
                     ;;
             esac
             OT_CMAKE_BUILD_DIR=${build_dir} ./script/build ${platform} ${build_type} "${options[@]}" "$@"
@@ -183,7 +187,8 @@ build()
             cd openthread-1.1
 
             # Prep
-            git clean -xfd
+            # TODO: Need to find some way to pull in GSDK 2.7 before starting efr32 builds in openthread 1.1
+            # git clean -xfd
             ./bootstrap
 
             # Build
@@ -193,7 +198,7 @@ build()
                     options+=("${build_1_1_env_nrf[@]}")
                     ;;
                 efr32*)
-                    options+=(${build_1_1_env_efr32[@]} BOARD=$(printf '%s\n' "$BOARD" | awk '{ print toupper($0) }'))
+                    options+=(${build_1_1_env_efr32[@]} BOARD=$(echo $BOARD | tr [a-z] [A-Z]))
                     ;;
             esac
             make -f examples/Makefile-${platform} "${options[@]}" "$@"
@@ -208,7 +213,8 @@ build()
             done
 
             # Clean up
-            git clean -xfd
+            # TODO: Need to find some way to pull in GSDK 2.7 before starting efr32 builds in openthread 1.1
+            # git clean -xfd
             ;;
     esac
 

--- a/script/make-reference-release.bash
+++ b/script/make-reference-release.bash
@@ -37,6 +37,7 @@ main()
     # Prebuild
     # ==========================================================================
     echo "REFERENCE_RELEASE_TYPE=${REFERENCE_RELEASE_TYPE?}"
+    mkdir -p build
     OUTPUT_ROOT=$(realpath build/ot-"${REFERENCE_RELEASE_TYPE?}-$(date +%Y%m%d)-$(cd openthread && git rev-parse --short HEAD)")
     mkdir -p $OUTPUT_ROOT
 

--- a/script/make-reference-release.bash
+++ b/script/make-reference-release.bash
@@ -29,41 +29,23 @@
 
 set -euxo pipefail
 
-readonly OT_PLATFORMS=(nrf52840 efr32mg1 efr32mg12 efr32mg13 efr32mg21)
+readonly OT_PLATFORMS=(nrf52840 efr32mg12)
 
 main()
 {
-    if [[ $# == 0 ]]; then
-        echo "Please specify a platform: ${OT_PLATFORMS[*]}"
-        exit 1
-    fi
-
-    # Check if the platform is supported.
-    platform="$1"
-    echo "${OT_PLATFORMS[@]}" | grep -wq "${platform}" || die "ERROR: Unsupported platform: ${platform}"
-    shift
-
     # ==========================================================================
     # Prebuild
     # ==========================================================================
-    mkdir -p build
     echo "REFERENCE_RELEASE_TYPE=${REFERENCE_RELEASE_TYPE?}"
     OUTPUT_ROOT=$(realpath build/ot-"${REFERENCE_RELEASE_TYPE?}-$(date +%Y%m%d)-$(cd openthread && git rev-parse --short HEAD)")
+    mkdir -p $OUTPUT_ROOT
 
     # ==========================================================================
     # Build firmware
     # ==========================================================================
-    mkdir -p "$OUTPUT_ROOT"/fw_dongle/
-
-    case "${platform}" in
-        nrf*)
-            OUTPUT_ROOT="$OUTPUT_ROOT"/fw_dongle/ ./script/make-firmware.bash "${platform}"
-            ;;
-
-        efr32*)
-            OUTPUT_ROOT="$OUTPUT_ROOT"/fw_dongle/ BOARD=${BOARD?Please specify a EFR32 Board} ./script/make-firmware.bash "${platform}"
-            ;;
-    esac
+    for platform in ${OT_PLATFORMS[@]}; do
+        OUTPUT_ROOT="$OUTPUT_ROOT"/fw_dongle_${platform}/ ./script/make-firmware.bash "${platform}"
+    done
 
     # ==========================================================================
     # Build THCI


### PR DESCRIPTION
This adds support for building efr32 images for Thread 1.3

It also refactors the `make-firmware.bash` and `make-reference-release.bash` scripts to allow other platforms to be easily added.